### PR TITLE
Removes the queue parameter from any Producer / Consumer function signature

### DIFF
--- a/consumer_test.go
+++ b/consumer_test.go
@@ -173,6 +173,25 @@ func (suite *ConsumerTestSuite) TestConsumeMessages_RealWorldScenarioWithErrors(
 	suite.Contains(m.Content.Name, "test another message")
 }
 
+func (suite *ConsumerTestSuite) TestAckMessage_WithError() {
+	queue := "test-queue"
+	consumer := squeue.NewConsumer[*TestMessage](suite.driver, queue)
+
+	msg := squeue.Message[*TestMessage]{
+		Content: &TestMessage{},
+		ID:      "123",
+	}
+
+	suite.driver.
+		EXPECT().
+		Ack(queue, "123").
+		Return(errors.New("ack error"))
+
+	err := consumer.Ack(msg)
+
+	suite.Error(err)
+}
+
 func TestConsumerTestSuite(t *testing.T) {
 	suite.Run(t, new(ConsumerTestSuite))
 }

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -31,28 +31,28 @@ func (suite *ConsumerTestSuite) TearDownTest() {
 }
 
 func (suite *ConsumerTestSuite) TestNewConsumer() {
-	squeue.NewConsumer[*TestMessage](suite.driver)
+	squeue.NewConsumer[*TestMessage](suite.driver, "test-queue")
 }
 
 func (suite *ConsumerTestSuite) TestConsumeMessages_DriverError() {
-	consumer := squeue.NewConsumer[*TestMessage](suite.driver)
-	ctx := context.Background()
 	queue := "test-queue"
+	consumer := squeue.NewConsumer[*TestMessage](suite.driver, queue)
+	ctx := context.Background()
 
 	suite.driver.
 		EXPECT().
 		Consume(ctx, queue).
 		Return(nil, errors.New("consume error"))
 
-	messages, err := consumer.Consume(ctx, queue)
+	messages, err := consumer.Consume(ctx)
 	suite.Nil(messages)
 	suite.Error(err)
 }
 
 func (suite *ConsumerTestSuite) TestConsumeMessages_OneMessageWithError() {
-	consumer := squeue.NewConsumer[*TestMessage](suite.driver)
-	ctx := context.Background()
 	queue := "test-queue"
+	consumer := squeue.NewConsumer[*TestMessage](suite.driver, queue)
+	ctx := context.Background()
 
 	dMessages := make(chan driver.Message)
 	go func() {
@@ -65,7 +65,7 @@ func (suite *ConsumerTestSuite) TestConsumeMessages_OneMessageWithError() {
 		Consume(ctx, queue).
 		Return(dMessages, nil)
 
-	messages, err := consumer.Consume(ctx, queue)
+	messages, err := consumer.Consume(ctx)
 
 	suite.NotNil(messages)
 	suite.Nil(err)
@@ -80,9 +80,9 @@ func (suite *ConsumerTestSuite) TestConsumeMessages_OneMessageWithError() {
 }
 
 func (suite *ConsumerTestSuite) TestConsumeMessages_OneMessageUnmarshallError() {
-	consumer := squeue.NewConsumer[*TestMessage](suite.driver)
-	ctx := context.Background()
 	queue := "test-queue"
+	consumer := squeue.NewConsumer[*TestMessage](suite.driver, queue)
+	ctx := context.Background()
 
 	dMessages := make(chan driver.Message)
 	go func() {
@@ -99,7 +99,7 @@ func (suite *ConsumerTestSuite) TestConsumeMessages_OneMessageUnmarshallError() 
 		Consume(ctx, queue).
 		Return(dMessages, nil)
 
-	messages, err := consumer.Consume(ctx, queue)
+	messages, err := consumer.Consume(ctx)
 
 	suite.NotNil(messages)
 	suite.Nil(err)
@@ -117,9 +117,9 @@ func (suite *ConsumerTestSuite) TestConsumeMessages_OneMessageUnmarshallError() 
 }
 
 func (suite *ConsumerTestSuite) TestConsumeMessages_RealWorldScenarioWithErrors() {
-	consumer := squeue.NewConsumer[*TestMessage](suite.driver)
-	ctx := context.Background()
 	queue := "test-queue"
+	consumer := squeue.NewConsumer[*TestMessage](suite.driver, queue)
+	ctx := context.Background()
 
 	dMessages := make(chan driver.Message)
 	go func() {
@@ -147,7 +147,7 @@ func (suite *ConsumerTestSuite) TestConsumeMessages_RealWorldScenarioWithErrors(
 		Consume(ctx, queue).
 		Return(dMessages, nil)
 
-	messages, err := consumer.Consume(ctx, queue)
+	messages, err := consumer.Consume(ctx)
 
 	suite.NotNil(messages)
 	suite.Nil(err)

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -1,9 +1,36 @@
 package driver
 
-import "context"
+func NewConsumerController() *ConsumerController {
+	return &ConsumerController{
+		data: make(chan Message),
+		done: make(chan struct{}),
+	}
+}
+
+type ConsumerController struct {
+	data chan Message
+	done chan struct{}
+}
+
+func (c *ConsumerController) Send(m Message) {
+	c.data <- m
+}
+
+func (c *ConsumerController) Data() <-chan Message {
+	return c.data
+}
+
+func (c *ConsumerController) Done() chan struct{} {
+	return c.done
+}
+
+func (c *ConsumerController) Stop() {
+	c.done <- struct{}{}
+	close(c.data)
+}
 
 type Driver interface {
 	Enqueue(queue string, data []byte, opts ...func(message any)) error
-	Consume(ctx context.Context, queue string, opts ...func(message any)) (chan Message, error)
+	Consume(queue string, opts ...func(message any)) (*ConsumerController, error)
 	Ack(queue string, messageID string) error
 }

--- a/driver/memdriver_test.go
+++ b/driver/memdriver_test.go
@@ -1,7 +1,6 @@
 package driver_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -43,20 +42,18 @@ func (suite *MemoryTestSuite) TestEnqueueDequeueSuccess() {
 	err = d.Enqueue("test", third)
 	suite.Nil(err)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	messages, err := d.Consume(ctx, "test")
+	ctrl, err := d.Consume("test")
 	suite.Nil(err)
 
-	m1 := <-messages
-	m2 := <-messages
-	m3 := <-messages
+	m1 := <-ctrl.Data()
+	m2 := <-ctrl.Data()
+	m3 := <-ctrl.Data()
+
+	ctrl.Stop()
 
 	suite.Equal(first, m1.Body)
 	suite.Equal(second, m2.Body)
 	suite.Equal(third, m3.Body)
-
 }
 
 func TestSQSTestSuite(t *testing.T) {

--- a/driver_test.go
+++ b/driver_test.go
@@ -5,7 +5,6 @@
 package squeue_test
 
 import (
-	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -50,22 +49,22 @@ func (mr *MockDriverMockRecorder) Ack(queue, messageID interface{}) *gomock.Call
 }
 
 // Consume mocks base method.
-func (m *MockDriver) Consume(ctx context.Context, queue string, opts ...func(any)) (chan driver.Message, error) {
+func (m *MockDriver) Consume(queue string, opts ...func(any)) (*driver.ConsumerController, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, queue}
+	varargs := []interface{}{queue}
 	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "Consume", varargs...)
-	ret0, _ := ret[0].(chan driver.Message)
+	ret0, _ := ret[0].(*driver.ConsumerController)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Consume indicates an expected call of Consume.
-func (mr *MockDriverMockRecorder) Consume(ctx, queue interface{}, opts ...interface{}) *gomock.Call {
+func (mr *MockDriverMockRecorder) Consume(queue interface{}, opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, queue}, opts...)
+	varargs := append([]interface{}{queue}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Consume", reflect.TypeOf((*MockDriver)(nil).Consume), varargs...)
 }
 

--- a/internal/examples/memory/main.go
+++ b/internal/examples/memory/main.go
@@ -55,19 +55,19 @@ func main() {
 
 	d := driver.NewMemoryDriver(time.Microsecond)
 
-	queue := squeue.NewProducer(d)
-	consumer := squeue.NewConsumer[*myMessage](d)
+	queue := squeue.NewProducer(d, "queue.test")
+	consumer := squeue.NewConsumer[*myMessage](d, "queue.test")
 
-	events, err := consumer.Consume(ctx, "queue.test")
+	events, err := consumer.Consume(ctx)
 	if err != nil {
 		panic(err)
 	}
 
-	_ = queue.Enqueue("queue.test", &myMessage{"foo"})
-	_ = queue.Enqueue("queue.test", &myMessage{"bar"})
-	_ = queue.Enqueue("queue.test", &myMessage{"baz"})
+	_ = queue.Enqueue(&myMessage{"foo"})
+	_ = queue.Enqueue(&myMessage{"bar"})
+	_ = queue.Enqueue(&myMessage{"baz"})
 
-	// Consumer gorouting
+	// Consumer goroutine
 	go func() {
 		for evt := range events {
 			log.Print("Received ", evt.Content)

--- a/internal/examples/sqs/consumer/consumer.go
+++ b/internal/examples/sqs/consumer/consumer.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"context"
 	"log"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 
 	"github.com/joho/godotenv"
@@ -42,9 +42,6 @@ func main() {
 		`)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	go cancelOnSignal(cancel, syscall.SIGINT, syscall.SIGTERM)
-
 	d, err := sqs.New(
 		sqs.WithUrl(os.Getenv("AWS_QUEUE_URL")),
 		sqs.WithRegion(os.Getenv("AWS_REGION")),
@@ -56,16 +53,27 @@ func main() {
 
 	q := "test-simone"
 	sub := squeue.NewConsumer[*sqsexample.MyEvent](d, q)
+	go cancelOnSignal(func() {
+		log.Println("Stopping consumer...")
+		sub.Stop()
+		log.Println("Stopped")
+	}, syscall.SIGINT, syscall.SIGTERM)
 
-	messages, err := sub.Consume(ctx)
+	messages, err := sub.Consume(
+		sqs.WithConsumeMaxNumberOfMessages(10),
+		sqs.WithConsumeWaitTimeSeconds(20),
+	)
 	if err != nil {
 		panic(err)
 	}
 
 	log.Print("Waiting for consuming")
+	wg := &sync.WaitGroup{}
 
 	for m := range messages {
+		wg.Add(1)
 		go func(message squeue.Message[*sqsexample.MyEvent]) {
+			defer wg.Done()
 			if message.Error != nil {
 				log.Printf("Received message with an error %+v", message.Error)
 				return
@@ -77,4 +85,6 @@ func main() {
 			}
 		}(m)
 	}
+
+	wg.Wait()
 }

--- a/internal/examples/sqs/consumer/consumer.go
+++ b/internal/examples/sqs/consumer/consumer.go
@@ -54,10 +54,10 @@ func main() {
 		panic(err)
 	}
 
-	sub := squeue.NewConsumer[*sqsexample.MyEvent](d)
 	q := "test-simone"
+	sub := squeue.NewConsumer[*sqsexample.MyEvent](d, q)
 
-	messages, err := sub.Consume(ctx, q)
+	messages, err := sub.Consume(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -72,7 +72,7 @@ func main() {
 			}
 
 			log.Printf("Received %s", message.Content.Name)
-			if err := sub.Ack(q, message); err != nil {
+			if err := sub.Ack(message); err != nil {
 				log.Print("Failed sending ack ", err)
 			}
 		}(m)

--- a/internal/examples/sqs/producer/producer.go
+++ b/internal/examples/sqs/producer/producer.go
@@ -40,7 +40,7 @@ func main() {
 	}
 
 	pub := squeue.NewProducer(d, "test-simone")
-	tick := time.Tick(time.Second * 2)
+	tick := time.Tick(time.Millisecond)
 
 	for i := 0; ; i++ {
 		<-tick

--- a/internal/examples/sqs/producer/producer.go
+++ b/internal/examples/sqs/producer/producer.go
@@ -39,11 +39,11 @@ func main() {
 		panic(err)
 	}
 
-	pub := squeue.NewProducer(d)
+	pub := squeue.NewProducer(d, "test-simone")
 	tick := time.Tick(time.Second * 2)
 
 	for i := 0; ; i++ {
 		<-tick
-		_ = pub.Enqueue("test-simone", &sqsexample.MyEvent{Name: fmt.Sprintf("Message #%d", i)})
+		_ = pub.Enqueue(&sqsexample.MyEvent{Name: fmt.Sprintf("Message #%d", i)})
 	}
 }

--- a/producer.go
+++ b/producer.go
@@ -6,24 +6,25 @@ import (
 	"github.com/simodima/squeue/driver"
 )
 
-func NewProducer(d driver.Driver) Producer {
+func NewProducer(d driver.Driver, queue string) Producer {
 	return Producer{
 		driver: d,
+		queue:  queue,
 	}
 }
 
 type Producer struct {
 	driver driver.Driver
+	queue  string
 }
 
-// Enqueue sends a message to the given queue
-// any provided options will be sent to the
-// underlying driver
-func (q *Producer) Enqueue(queue string, message json.Marshaler, opts ...func(message any)) error {
+// Enqueue sends a message to the underlying queue,
+// any provided options will be sent to the driver.
+func (q *Producer) Enqueue(message json.Marshaler, opts ...func(message any)) error {
 	data, err := json.Marshal(message)
 	if err != nil {
 		return wrapErr(err, ErrMarshal, nil)
 	}
 
-	return q.driver.Enqueue(queue, data, opts...)
+	return q.driver.Enqueue(q.queue, data, opts...)
 }

--- a/producer_test.go
+++ b/producer_test.go
@@ -39,45 +39,45 @@ func (suite *QueueTestSuite) TearDownTest() {
 }
 
 func (suite *QueueTestSuite) TestNewProducer() {
-	squeue.NewProducer(suite.driver)
+	squeue.NewProducer(suite.driver, "test-queue")
 }
 
 func (suite *QueueTestSuite) TestEnqueueMessage_DriverError() {
 	queue := "test-queue"
-	producer := squeue.NewProducer(suite.driver)
+	producer := squeue.NewProducer(suite.driver, queue)
 
 	suite.driver.
 		EXPECT().
 		Enqueue(queue, []byte(`{"name":"test message"}`)).
 		Return(errors.New("producer error"))
 
-	err := producer.Enqueue(queue, &TestMessage{Name: "test message"})
+	err := producer.Enqueue(&TestMessage{Name: "test message"})
 	suite.Error(err)
 }
 
 func (suite *QueueTestSuite) TestEnqueueMessage_MarshalingError() {
 	queue := "test-queue"
-	producer := squeue.NewProducer(suite.driver)
+	producer := squeue.NewProducer(suite.driver, queue)
 
 	suite.driver.
 		EXPECT().
 		Enqueue(queue, nil).
 		Times(0)
 
-	err := producer.Enqueue(queue, &wrongMessage{})
+	err := producer.Enqueue(&wrongMessage{})
 	suite.Error(err)
 }
 
 func (suite *QueueTestSuite) TestEnqueueMessage() {
 	queue := "test-queue"
-	producer := squeue.NewProducer(suite.driver)
+	producer := squeue.NewProducer(suite.driver, queue)
 	message := &TestMessage{Name: "test message"}
 	suite.driver.
 		EXPECT().
 		Enqueue(queue, []byte(`{"name":"test message"}`)).
 		Return(nil)
 
-	err := producer.Enqueue(queue, message)
+	err := producer.Enqueue(message)
 	suite.Nil(err)
 }
 


### PR DESCRIPTION

The Producer / Consumer will be created for a fixed queue for a more consistency in the queue - message type association. For any give message type there will be a queue by design, so it makes sense to provide the queue name only in the construct functions.